### PR TITLE
Fix ugly non-sense strings in signup page

### DIFF
--- a/cms/server/PracticeWebServer.py
+++ b/cms/server/PracticeWebServer.py
@@ -183,23 +183,23 @@ class APIHandler(object):
 
     def check_user(self, username):
         if len(username) < 4:
-            return 'signup.errors.username.short'
+            return 'Username is too short'
         elif not self.USERNAME_REG.match(username):
-            return 'signup.errors.username.invalid'
+            return 'Username is invalid'
         else:
             user = local.session.query(User)\
                 .filter(User.username == username).first()
             if user is not None:
-                return 'signup.errors.username.used'
+                return 'This username is not available'
 
     def check_email(self, email):
         if not self.EMAIL_REG.match(email):
-            return 'signup.errors.email.invalid'
+            return 'Invalid e-mail'
         else:
             user = local.session.query(User)\
                 .filter(User.email == email).first()
             if user is not None:
-                return 'signup.errors.email.used'
+                return 'E-mail already used'
 
     def hash(self, string, algo='sha256'):
         if string is None:

--- a/cms/web/practice/js/signup.js
+++ b/cms/web/practice/js/signup.js
@@ -57,13 +57,13 @@ angular.module('pws.signup', [])
       'password2': ''
     };
     $scope.errorMsg = {
-      'password':  'signup.errors.password',
-      'password2': 'signup.errors.password2',
-      'email2':    'signup.errors.email.match',
-      'region':    'signup.errors.region',
-      'province':  'signup.errors.province',
-      'city':      'signup.errors.city',
-      'institute': 'signup.errors.institute'
+      'password':  'Password\'s too short',
+      'password2': 'Passwords don\'t match',
+      'email2':    'E-mails don\'t match',
+      'region':    'You must specify a region',
+      'province':  'You must specify a province',
+      'city':      'You must specify a city',
+      'institute': 'You must specify an institute'
     };
     $http.post('location', {
       'action': 'listregions'

--- a/cms/web/practice/views/signup.html
+++ b/cms/web/practice/views/signup.html
@@ -3,23 +3,23 @@
     <div class="col-sm-6">
       <form class="form-horizontal" role="form" ng-submit="submit()" name="signupform">
         <fieldset>
-          <legend>{{'signup.ui.loginData.title' | l10n}}</legend>
+          <legend>{{'Login data' | l10n}}</legend>
           <div class="form-group" ng-class="{'has-error': signupform.username.$dirty && isBad['username']}">
-            <label class="col-sm-4 control-label" for="username1">{{'signup.ui.loginData.username' | l10n}}</label>
+            <label class="col-sm-4 control-label" for="username1">{{'Username' | l10n}}</label>
             <div class="col-sm-6">
               <input class="form-control" maxlength="15" autocomplete="off" type="text" id="username1" name="username" ng-model="user.username" ng-change="checkUsername()"/>
               <span class="help-block" ng-show="signupform.username.$dirty && isBad['username']">{{errorMsg['username'] | l10n}}</span>
             </div>
           </div>
           <div class="form-group" ng-class="{'has-error': signupform.password.$dirty && isBad['password']}">
-            <label class="col-sm-4 control-label" for="password1">{{'signup.ui.loginData.password' | l10n}}</label>
+            <label class="col-sm-4 control-label" for="password1">{{'Password' | l10n}}</label>
             <div class="col-sm-6">
               <input class="form-control" autocomplete="off" type="password" id="password1" name="password" ng-model="user.password" ng-change="checkPassword(); matchPassword()"/>
               <span class="help-block" ng-show="signupform.password.$dirty && isBad['password']">{{errorMsg['password'] | l10n}}</span>
             </div>
           </div>
           <div class="form-group" ng-class="{'has-error': signupform.password2.$dirty && isBad['password2']}">
-            <label class="col-sm-4 control-label" for="password2">{{'signup.ui.loginData.password2' | l10n}}</label>
+            <label class="col-sm-4 control-label" for="password2">{{'Confirm password' | l10n}}</label>
             <div class="col-sm-6">
               <input class="form-control" autocomplete="off" type="password" id="password2" name="password2" ng-model="user.password2" ng-change="matchPassword()"/>
               <span class="help-block" ng-show="signupform.password2.$dirty && isBad['password2']">{{errorMsg['password2'] | l10n}}</span>
@@ -27,28 +27,28 @@
           </div>
         </fieldset>
         <fieldset>
-          <legend>{{'signup.ui.personalData.title' | l10n}}</legend>
+          <legend>{{'Personal data' | l10n}}</legend>
           <div class="form-group">
-            <label class="col-sm-4 control-label" for="firstname">{{'signup.ui.personalData.firstname' | l10n}}</label>
+            <label class="col-sm-4 control-label" for="firstname">{{'First name' | l10n}}</label>
             <div class="col-sm-6">
               <input class="form-control" maxlength="30" autocomplete="off" type="text" id="firstname" ng-model="user.firstname"/>
             </div>
           </div>
           <div class="form-group">
-            <label class="col-sm-4 control-label" for="lastname">{{'signup.ui.personalData.lastname' | l10n}}</label>
+            <label class="col-sm-4 control-label" for="lastname">{{'Last name' | l10n}}</label>
             <div class="col-sm-6">
               <input class="form-control" maxlength="30" autocomplete="off" type="text" id="lastname" ng-model="user.lastname"/>
             </div>
           </div>
           <div class="form-group" ng-class="{'has-error': signupform.email.$dirty && isBad['email']}">
-            <label class="col-sm-4 control-label" for="email1">{{'signup.ui.personalData.email' | l10n}}</label>
+            <label class="col-sm-4 control-label" for="email1">{{'E-mail address' | l10n}}</label>
             <div class="col-sm-6">
               <input class="form-control" autocomplete="off" type="text" id="email1" name="email" ng-model="user.email" ng-change="checkEmail(); matchEmail()"/>
               <span class="help-block" ng-show="signupform.email.$dirty && isBad['email']">{{errorMsg['email'] | l10n}}</span>
             </div>
           </div>
           <div class="form-group" ng-class="{'has-error': signupform.email2.$dirty && isBad['email2']}">
-            <label class="col-sm-4 control-label" for="email2">{{'signup.ui.personalData.email2' | l10n}}</label>
+            <label class="col-sm-4 control-label" for="email2">{{'Confirm e-mail' | l10n}}</label>
             <div class="col-sm-6">
               <input class="form-control" autocomplete="off" type="text" id="email2" name="email2" ng-model="user.email2" ng-change="matchEmail()"/>
               <span class="help-block" ng-show="signupform.email2.$dirty && isBad['email2']">{{errorMsg['email2'] | l10n}}</span>
@@ -56,9 +56,9 @@
           </div>
         </fieldset>
         <fieldset>
-          <legend>{{'signup.ui.instituteData.title' | l10n}}</legend>
+          <legend>{{'Institute data' | l10n}}</legend>
           <div class="form-group" ng-class="{'has-error': signupform.region.$dirty && isBad['region']}">
-            <label class="col-sm-4 control-label" for="region">{{'signup.ui.instituteData.region' | l10n}}</label>
+            <label class="col-sm-4 control-label" for="region">{{'Region' | l10n}}</label>
             <div class="col-sm-6">
               <select id="region" name="region" ng-model="user.region" class="form-control" ng-change="resetProvince(); checkRegion()">
                 <option ng-repeat="r in regions | orderBy:'name'" value="{{r.id}}">{{r.name}}</option>
@@ -67,7 +67,7 @@
             </div>
           </div>
           <div class="form-group" ng-class="{'has-error': signupform.province.$dirty && isBad['province']}">
-            <label class="col-sm-4 control-label" for="province">{{'signup.ui.instituteData.province' | l10n}}</label>
+            <label class="col-sm-4 control-label" for="province">{{'Province' | l10n}}</label>
             <div class="col-sm-6">
               <select id="province" name="province" ng-model="user.province" class="form-control" ng-change="resetCity(); checkProvince()" ng-disabled="isBad['region']">
                 <option ng-repeat="p in provinces | orderBy:'name'" value="{{p.id}}">{{p.name}}</option>
@@ -76,7 +76,7 @@
             </div>
           </div>
           <div class="form-group" ng-class="{'has-error': signupform.city.$dirty && isBad['city']}">
-            <label class="col-sm-4 control-label" for="city">{{'signup.ui.instituteData.city' | l10n}}</label>
+            <label class="col-sm-4 control-label" for="city">{{'City' | l10n}}</label>
             <div class="col-sm-6">
               <select id="city" name="city" ng-model="user.city" class="form-control" ng-change="resetInstitute(); checkCity()" ng-disabled="isBad['province']">
                 <option ng-repeat="c in cities | orderBy:'name'" value="{{c.id}}">{{c.name}}</option>
@@ -85,7 +85,7 @@
             </div>
           </div>
           <div class="form-group" ng-class="{'has-error': signupform.institute.$dirty && isBad['institute']}">
-            <label class="col-sm-4 control-label" for="institute">{{'signup.ui.instituteData.institute' | l10n}}</label>
+            <label class="col-sm-4 control-label" for="institute">{{'Institute' | l10n}}</label>
             <div class="col-sm-6">
               <select id="institute" name="institute" ng-model="user.institute" class="form-control" ng-change="checkInstitute()" ng-disabled="isBad['city']">
                 <option ng-repeat="i in institutes | orderBy:'name'" value="{{i.id}}">{{i.name}}</option>
@@ -96,13 +96,13 @@
         </fieldset>
         <div class="form-group">
           <div class="col-sm-offset-4 col-sm-8">
-            <button type="submit" class="btn btn-default">{{'signup.ui.buttons.register' | l10n}}</button>
+            <button type="submit" class="btn btn-default">{{'Sign up' | l10n}}</button>
           </div>
         </div>
       </form>
     </div>
     <div class="col-sm-6 hidden-xs">
-      <legend>{{'signup.ui.userPreview.title' | l10n}}</legend>
+      <legend>{{'User profile preview' | l10n}}</legend>
       <div class="user-preview well well-lg col-sm-offset-1 col-sm-9 col-md-offset-2 col-md-8">
         <div class="avatar-wrapper">
           <img src="http://gravatar.com/avatar/d41d8cd98f00b204e9800998ecf8427e?d=identicon&s=200" class="avatar img-thumbnail"/>


### PR DESCRIPTION
We need badly to (at least temporary) fix strings shown when a user registers.
Now one see unmeaningful string such as "signup.ui.loginData.username" which is clearly not the intended behaviour.
This is a regression of commit 836274ad0aff5131efb5741750aec9583a6e2672 that totally changed the way the l10n is handled. This lead e.g. "signup.ui.loginData.username" to mean nothing (also making it not translatable obviously).
This fix aims at showing decent strings.
