### PR TITLE
User profile: show institute info only if available

### DIFF
--- a/cms/web/practice/views/user.profile.html
+++ b/cms/web/practice/views/user.profile.html
@@ -9,7 +9,9 @@
         <small class="label label-default">{{user.access_level | levelClass}}</small>
       </h3>
       <br />
-      <i class="fa fa-home fa-lg"></i> {{user.institute.name}} ({{user.institute.province}})
+      <span ng-if="user.institute.name">
+        <i class="fa fa-home fa-lg"></i> {{user.institute.name}} ({{user.institute.province}})
+      </span>
       <br />
       <span ng-if="!isMe()">
         <i class="fa fa-comment fa-lg"></i> <a ui-sref="talkRedirect({userId: myName(), recipientName: user.username})">{{'Send message' | l10n}}</a>


### PR DESCRIPTION
Attualmente, quando non vi sono reperibili le informazioni della scuola di un utente, viene mostrato questo. ![schermata del 2014-02-20 20 18 20](https://f.cloud.github.com/assets/2065805/2222303/efdc6234-9a63-11e3-970e-3363ea0a1869.png)
