### PR TITLE
Utilizzo del visualizzatore pdf nativo quando disponibile

### DIFF
--- a/cms/web/practice/js/task.js
+++ b/cms/web/practice/js/task.js
@@ -126,10 +126,7 @@ angular.module('pws.task', [])
     taskbarManager.setActiveTab(1);
     $scope.goodBrowser = !!$window.Worker;
     $scope.getPDFURL = function(hash) {
-      return 'assets/pdfjs/web/viewer.html?file=' + location.pathname.replace(/[^\/]*$/, '') + 'files/' + hash + '/testo.pdf';
-    };
-    $scope.getPDFURLforIE8 = function(hash) {
-      return 'files/' + hash + '/testo.pdf';
+      return location.pathname.replace(/[^\/]*$/, '') + 'files/' + hash + '/testo.pdf';
     };
   })
   .controller('AttachmentsCtrl', function(taskbarManager) {
@@ -219,5 +216,19 @@ angular.module('pws.task', [])
     };
     $scope.showDetails = function(id) {
       subsDatabase.subDetails(id);
+    };
+  })
+  .directive('pdf', function() {
+    return {
+      restrict: 'E',
+      link: function(scope, element, attrs) {
+        var hasBuiltInPdf = !("ActiveXObject" in window) && !/iPhone|iPod|Android|BlackBerry|Opera Mini|Phone|Mobile/i.test(navigator.userAgent);
+        if (hasBuiltInPdf)
+          element.replaceWith('<object data="' + attrs.src + '" type="application/pdf" class="' + attrs.class + 
+            '">Update your browser!</object>');
+        else
+          element.replaceWith('<iframe seamless src="assets/pdfjs/web/viewer.html?file=' + attrs.src +
+            '" class="' + attrs.class +'"/>');
+      }
     };
   });

--- a/cms/web/practice/js/task.js
+++ b/cms/web/practice/js/task.js
@@ -224,10 +224,10 @@ angular.module('pws.task', [])
       link: function(scope, element, attrs) {
         var hasBuiltInPdf = !("ActiveXObject" in window) && !/iPhone|iPod|Android|BlackBerry|Opera Mini|Phone|Mobile/i.test(navigator.userAgent);
         if (hasBuiltInPdf)
-          element.replaceWith('<object data="' + attrs.src + '" type="application/pdf" class="' + attrs.class + 
+          element.replaceWith('<object data="' + attrs.ngSrc + '" type="application/pdf" class="' + attrs.class + 
             '">Update your browser!</object>');
         else
-          element.replaceWith('<iframe seamless src="assets/pdfjs/web/viewer.html?file=' + attrs.src +
+          element.replaceWith('<iframe seamless src="assets/pdfjs/web/viewer.html?file=' + attrs.ngSrc +
             '" class="' + attrs.class +'"/>');
       }
     };

--- a/cms/web/practice/views/task.statement.html
+++ b/cms/web/practice/views/task.statement.html
@@ -1,5 +1,5 @@
 <div class="row container text-center" >
-  <pdf ng-if="goodBrowser == true" src="{{getPDFURL(task.statements.it)}}" class="viewer"/>
+  <pdf ng-if="goodBrowser == true" ng-src="{{getPDFURL(task.statements.it)}}" class="viewer"/>
   <a ng-if="goodBrowser == false" href="{{getPDFURL(task.statements.it)}}" class="btn btn-lg btn-success">
     Download
   </a>

--- a/cms/web/practice/views/task.statement.html
+++ b/cms/web/practice/views/task.statement.html
@@ -1,6 +1,3 @@
 <div class="row container text-center" >
-  <pdf ng-if="goodBrowser == true" ng-src="{{getPDFURL(task.statements.it)}}" class="viewer"/>
-  <a ng-if="goodBrowser == false" href="{{getPDFURL(task.statements.it)}}" class="btn btn-lg btn-success">
-    Download
-  </a>
+  <pdf class="viewer ng-scope"/>
 </div>

--- a/cms/web/practice/views/task.statement.html
+++ b/cms/web/practice/views/task.statement.html
@@ -1,8 +1,6 @@
-<div class="row container text-center" ng-if="goodBrowser == true" >
-  <iframe ng-if="task !== undefined" seamless ng-src="{{getPDFURL(task.statements.it)}}" class="viewer"></iframe>
-</div>
-<div class="row container text-center" ng-if="goodBrowser == false" >
-  <a href="{{getPDFURLforIE8(task.statements.it)}}" class="btn btn-lg btn-success">
+<div class="row container text-center" >
+  <pdf ng-if="goodBrowser == true" src="{{getPDFURL(task.statements.it)}}" class="viewer"/>
+  <a ng-if="goodBrowser == false" href="{{getPDFURL(task.statements.it)}}" class="btn btn-lg btn-success">
     Download
   </a>
 </div>


### PR DESCRIPTION
In caso non lo sia fa il fallback a PDF.js, come discusso nel [forum](http://cms.di.unipi.it:8000/t/visualizzazione-pdf-testo-problemi/331). Non ho però usato PDFObject2, ma fatto un'implementazione custom (che oltre tutto è anche più corta), in quanto il metodo che utilizza per capire se è disponibile un visualizzatore nativo non è efficace su browser diversi da chrome.

I vantaggi sono:
- Risolve il problema per il quale chrome non copia correttamente gli "a capo" in pdf.js
- Velocizza il caricamento della pagina
- Dimuisce la ram utilizzata dalla pagina (60-70MB in meno)
- Diminuisce drasticamente la cpu utilizzata durante lo scrolling (da 20-30% a 1-2% in chrome)
